### PR TITLE
Add course-restore preprocessing argument

### DIFF
--- a/Moosh/Command/Moodle39/Course/CourseRestore.php
+++ b/Moosh/Command/Moodle39/Course/CourseRestore.php
@@ -19,6 +19,9 @@ class CourseRestore extends MooshCommand {
 
         $this->addArgument('backup_file');
         $this->addArgument('category_id');
+        $this->addArgument('preprocess', );
+        // preprocessing is optional
+        $this->minArguments--;
 
         $this->addOption('d|directory', 'restore from extracted directory (1st param) under tempdir/backup');
         $this->addOption('e|existing', 'restore into existing course, id provided instead of category_id');
@@ -96,6 +99,18 @@ class CourseRestore extends MooshCommand {
             $fp->extract_to_pathname($arguments[0], $path);
         } else {
             $backupdir = $arguments[0];
+        }
+
+        if(!empty($arguments[2])) {
+            if(!file_exists($arguments[2])) {
+                echo "Preprocessing script '" . $arguments[2] . "' does not exist" . PHP_EOL;
+                exit(1);
+            }
+            if($this->verbose) {
+                echo "Using preprocessing script '" . $arguments[2] . "'" . PHP_EOL;
+            }
+            require $arguments[2];
+            moosh_preprocess_mbz($path, $this->verbose);
         }
 
         //extract original full & short names

--- a/Moosh/Command/Moodle39/Course/CourseRestore.php
+++ b/Moosh/Command/Moodle39/Course/CourseRestore.php
@@ -19,14 +19,12 @@ class CourseRestore extends MooshCommand {
 
         $this->addArgument('backup_file');
         $this->addArgument('category_id');
-        $this->addArgument('preprocess', );
-        // preprocessing is optional
-        $this->minArguments--;
 
         $this->addOption('d|directory', 'restore from extracted directory (1st param) under tempdir/backup');
         $this->addOption('e|existing', 'restore into existing course, id provided instead of category_id');
         $this->addOption('o|overwrite', 'restore into existing course, overwrite current content, id provided instead of category_id');
         $this->addOption('i|ignore-warnings', 'continue with restore if there are pre-check warnings');
+        $this->addOption('p|preprocess:', 'provide a path to a backup preprocessing script', '');
     }
 
     public function execute() {
@@ -101,15 +99,15 @@ class CourseRestore extends MooshCommand {
             $backupdir = $arguments[0];
         }
 
-        if(!empty($arguments[2])) {
-            if(!file_exists($arguments[2])) {
-                echo "Preprocessing script '" . $arguments[2] . "' does not exist" . PHP_EOL;
+        if (!empty($options['preprocess'])) {
+            if(!file_exists($options['preprocess'])) {
+                echo "Preprocessing script '" . $options['preprocess'] . "' does not exist" . PHP_EOL;
                 exit(1);
             }
             if($this->verbose) {
-                echo "Using preprocessing script '" . $arguments[2] . "'" . PHP_EOL;
+                echo "Using preprocessing script '" . $options['preprocess'] . "'" . PHP_EOL;
             }
-            require $arguments[2];
+            require $options['preprocess'];
             moosh_preprocess_mbz($path, $this->verbose);
         }
 

--- a/www/commands/index.md
+++ b/www/commands/index.md
@@ -1104,6 +1104,10 @@ Example 4: Restore backup.mbz into existing course with id=3, overwrite course c
 
     moosh course-restore --overwrite backup.mbz 3
 
+Example 5: Restore backup.mbz into category with id=1 and apply a preprocessing script. The script should define a function `moosh_preprocess_mbz($path: string, $verbose: bool): void`, where `$path` is a path to the unarchived backup and `$verbose` is a verbosity flag.
+
+    moosh course-restore --preprocess preprocessing-script.php backup.mbz 1
+
 course-unenrol
 --------------
 


### PR DESCRIPTION
Add course-restore preprocessing argument as the third, optional argument to the command `course-restore`, so that the new arguments list is:
```
course-restore backup_file category_id [preprocess]
```

If provided, the course restore process then includes preprocess script file, which is expected to include a function named `moosh_preprocess_mbz($path, $verbose = false)`. The first argument of this function is path to the unpacked MBZ backup file, which the preprocessing script can modify as needed. The second is just verbosity flag.

This way, Moodle admins can modify the backups they are importing any way they see fit by modifying the XMLs. Our use case would be changing the users authentication type based on predefined exported profile fields and merging duplicate accounts before importing the backup.